### PR TITLE
adjust tomcat memory settings to fit in 4Gb

### DIFF
--- a/roles/tomcat/templates/config-georchestra.j2
+++ b/roles/tomcat/templates/config-georchestra.j2
@@ -1,5 +1,5 @@
 JAVA_OPTS="-Djava.awt.headless=true -XX:+UseConcMarkSweepGC \
-	-Xms2G \
+	-Xms1G \
 	-Xmx2G \
 	-XX:MaxPermSize=256m \
 	-Djavax.net.ssl.trustStore=/etc/tomcat8/keystore \

--- a/roles/tomcat/templates/config-geoserver.j2
+++ b/roles/tomcat/templates/config-geoserver.j2
@@ -1,6 +1,6 @@
 JAVA_OPTS="-Djava.awt.headless=true -XX:+UseConcMarkSweepGC \
-	-Xms2G \
-	-Xmx2G \
+	-Xms512m \
+	-Xmx1G \
 	-XX:MaxPermSize=256m \
 	-XX:PermSize=256m \
 	-Djavax.net.ssl.trustStore=/etc/tomcat8/keystore \

--- a/roles/tomcat/templates/config-proxycas.j2
+++ b/roles/tomcat/templates/config-proxycas.j2
@@ -1,6 +1,6 @@
 JAVA_OPTS="-Djava.awt.headless=true -XX:+UseConcMarkSweepGC \
 	-Xms256m \
-	-Xmx256m \
+	-Xmx512m \
 	-XX:MaxPermSize=128m \
 	-Dgeorchestra.datadir={{ georchestra.datadir.path }} \
 	-Djavax.net.ssl.trustStore=/etc/tomcat8/keystore \


### PR DESCRIPTION
Tomcats need:
 * 2 Gb for all webapps, including GN3
 * 1 Gb for GeoServer
 * 512 Mb for proxy + cas

This leaves ~ 500 Mb for the system, which is fine for the default VM bootstraped with vagrant.
XMS also adjusted to leave room...
