### PR TITLE
debian bullseye support

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/README.md
+++ b/README.md
@@ -56,3 +56,15 @@ To browse your SDI, just drop a line in your ```/etc/hosts``` file, registering 
 192.168.0.19 georchestra.example.org
 ```
 ... and open https://georchestra.example.org/geonetwork/ in your browser.
+
+# Serverspec
+
+a serverspec testsuite is provided to test the vagrant environments Once the box is up (see previous section),
+you can test the setup with the following command:
+
+```
+$ rake spec
+```
+
+This will require the `ruby-serverspec` package to be installed on the host.
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,27 @@
+require 'rake'
+require 'rspec/core/rake_task'
+
+task :spec    => 'spec:all'
+task :default => :spec
+
+namespace :spec do
+  targets = []
+  Dir.glob('./spec/*').each do |dir|
+    next unless File.directory?(dir)
+    target = File.basename(dir)
+    target = "_#{target}" if target == "default"
+    targets << target
+  end
+
+  task :all     => targets
+  task :default => :all
+
+  targets.each do |target|
+    original_target = target == "_default" ? target[1..-1] : target
+    desc "Run serverspec tests to #{original_target}"
+    RSpec::Core::RakeTask.new(target.to_sym) do |t|
+      ENV['TARGET_HOST'] = original_target
+      t.pattern = "spec/#{original_target}/*_spec.rb"
+    end
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "debian/buster64"
+  config.vm.box = "debian/bullseye64"
 
   # set CPU and RAM
   config.vm.provider "virtualbox" do |vb|

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,3 +1,3 @@
 # ansible roles from galaxy
-- elastic.elasticsearch,7.13.4
+- elastic.elasticsearch,v7.13.4
 - geerlingguy.kibana,4.0.1

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -8,18 +8,36 @@
     name: sudo
     state: present
 
-- name: installing dependencies
+- name: installing dependencies (buster)
   apt:
     pkg: ['postgis', 'postgresql-11-postgis-2.5', 'postgresql-11-postgis-2.5-scripts', 'postgresql-contrib']
     state: present
     update_cache: yes
+  when: ansible_distribution_release == "buster"
 # postgresql-11-postgis-2.5-scripts #for postgis.control
 # postgresql-contrib #for dblink extension
 
-- name: install python-psycopg2 for ansible psql modules
+- name: installing dependencies (bullseye)
+  apt:
+    pkg: ['postgis', 'postgresql-13-postgis-3', 'postgresql-13-postgis-3-scripts', 'postgresql-contrib']
+    state: present
+    update_cache: yes
+  when: ansible_distribution_release == "bullseye"
+# postgresql-11-postgis-2.5-scripts #for postgis.control
+# postgresql-contrib #for dblink extension
+
+
+- name: install python-psycopg2 for ansible psql modules (buster)
   apt:
     name: python-psycopg2
     state: present
+  when: ansible_distribution_release == "buster"
+
+- name: install python-psycopg2 for ansible psql modules (bullseye)
+  apt:
+    name: python3-psycopg2
+    state: present
+  when: ansible_distribution_release == "bullseye"
 
 - name: create georchestra user
   become: yes

--- a/roles/tomcat/tasks/common.yml
+++ b/roles/tomcat/tasks/common.yml
@@ -1,3 +1,8 @@
+- name: ensure GPG is installed
+  apt:
+    name: gpg
+    state: present
+
 - name: add adoptopenjdk repository key
   tags: java8
   apt_key:

--- a/spec/georchestra/georchestra_spec.rb
+++ b/spec/georchestra/georchestra_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe package('apache2') do
+  it { should be_installed }
+end
+
+# Frontend webserver (apache2)
+describe port(80) do
+  it { should be_listening }
+end
+
+describe port(443) do
+  it { should be_listening }
+end
+
+# postgresql
+describe port(5432) do
+  it { should be_listening }
+end
+
+# OpenLDAP / slapd
+describe port(389) do
+  it { should be_listening }
+end
+
+# Elasticsearch
+describe port(9200) do
+  it { should be_listening }
+end
+
+# Kibana
+describe port(5601) do
+  it { should be_listening }
+end
+
+# tomcat-georchestra
+describe port(8280) do
+  it { should be_listening }
+end
+
+# tomcat-geoserver
+describe port(8380) do
+  it { should be_listening }
+end
+
+# tomcat-proxycas
+describe port(8180) do
+  it { should be_listening }
+end
+
+describe port(8443) do
+  it { should be_listening }
+end
+
+# datafeeder
+describe port(8480) do
+  it { should be_listening }
+end
+
+# geOrchestra base debian packages should be present
+[ 'georchestra-analytics',
+  'georchestra-cas',
+  'georchestra-console',
+  'georchestra-datafeeder',
+  'georchestra-datafeeder-ui',
+  'georchestra-extractorapp',
+  'georchestra-geoserver',
+  'georchestra-geowebcache',
+  'georchestra-header',
+  'georchestra-mapfishapp',
+  'georchestra-security-proxy',
+].each do |pkg|
+  describe package(pkg) do
+    it { should be_installed }
+  end
+end
+
+# geOrchestra datadir has been set up
+describe file('/etc/georchestra') do
+  it { should be_directory }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,41 @@
+require 'serverspec'
+require 'net/ssh'
+require 'tempfile'
+
+set :backend, :ssh
+
+if ENV['ASK_SUDO_PASSWORD']
+  begin
+    require 'highline/import'
+  rescue LoadError
+    fail "highline is not available. Try installing it."
+  end
+  set :sudo_password, ask("Enter sudo password: ") { |q| q.echo = false }
+else
+  set :sudo_password, ENV['SUDO_PASSWORD']
+end
+
+host = ENV['TARGET_HOST']
+
+`vagrant up #{host}`
+
+config = Tempfile.new('', Dir.tmpdir)
+config.write(`vagrant ssh-config #{host}`)
+config.close
+
+options = Net::SSH::Config.for(host, [config.path])
+
+options[:user] ||= Etc.getlogin
+
+set :host,        options[:host_name] || host
+set :ssh_options, options
+
+# Disable sudo
+set :disable_sudo, true
+
+
+# Set environment variables
+# set :env, :LANG => 'C', :LC_MESSAGES => 'C'
+
+# Set PATH
+# set :path, '/sbin:/usr/local/sbin:$PATH'


### PR DESCRIPTION
See #88.

* fixes the ansible-galaxy version number for the elasticsearch role
* migrates the vagrant box to 'debian/bullseye64', the playbook has been adapted to remain compatible with buster, though
* adding a serverspec testsuite for vagrant, documenting how to use it

tests: ansible-playbook went well when `vagrant provision`, but the serverspec testsuite reveals some caveats:

* there is an non critical issue at tomcat-proxycas's startup, and the SSL/TLS connector is unavailable (so nothing is actually listening onto the 8443 tcp port)
* as no smtp is provided by default, the datafeeder is unable to run, so the test on the df port is also failing

