### PR TITLE
Introducing geonetwork-cloud-searching webservice

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,6 +33,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.groups = {
       "mygeorchestra" => ["georchestra"]
     }
+    # If needed to test a part of the playbook by limiting to a specific tag
+    #ansible.raw_arguments = ["-t", "gn-cloud-searching"]
   end
 
   config.vm.post_up_message = "geOrchestra SDI installed, congrats! See https://www.georchestra.org/community.html for help and bug reports"

--- a/playbooks/georchestra.yml
+++ b/playbooks/georchestra.yml
@@ -201,7 +201,10 @@
     datafeeder:
       enabled: true
       port: 8480
-
+    gn_cloud_searching:
+      enabled: true
+      port: 8580
+      url: https://api.github.com/repos/georchestra/geonetwork-microservices/actions/artifacts/93336082/zip
   tasks:
     - name: reconfigure Kibana after geerlingguy.kibana
       copy:

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -102,6 +102,14 @@
   - { src: common, dest: cadastrapp }
   notify: reload apache2
 
+- name: template config for gn-cloud-searching
+  tags: apache_config
+  template:
+    src: gn-cloud-searching.conf.j2
+    dest: "/var/www/georchestra/conf/gn-cloud-searching.conf"
+  notify: reload apache2
+  when: gn_cloud_searching.enabled
+
 - name: generate self-signed cert
   command: >
     openssl req -new -nodes -x509 -subj "/C=FR/L=Somewhere/O=IT/CN={{ georchestra.fqdn }}"

--- a/roles/apache/templates/gn-cloud-searching.conf.j2
+++ b/roles/apache/templates/gn-cloud-searching.conf.j2
@@ -1,0 +1,24 @@
+<Proxy http://localhost:{{ gn_cloud_searching.port }}/portal/*>
+    Require all granted
+</Proxy>
+
+# I'd have like to be more generic than that, but it
+# already took me ages to find out how to do a simple
+# proxypass with Apache2.
+# (I tried with LocationMatch & a regex with no luck in
+# an acceptable amount of time).
+
+<Location /geonetwork/srv/fre/rss.search>
+  ProxyPass http://localhost:{{ gn_cloud_searching.port }}/portal/api/search/records/rss.search
+  Header set  Content-Type "application/rss+xml; charset=utf-8"
+
+  # For an obscure reason, if the Accept-Encoding header is set to "gzip,deflate"
+  # then the microservices is returning an empty response.
+  RequestHeader unset Accept-Encoding
+</Location>
+
+<Location /geonetwork/srv/eng/rss.search>
+  ProxyPass http://localhost:{{ gn_cloud_searching.port }}/portal/api/search/records/rss.search
+  Header set  Content-Type "application/rss+xml; charset=utf-8"
+  RequestHeader unset Accept-Encoding
+</Location>

--- a/roles/georchestra/tasks/gn-cloud-searching.yml
+++ b/roles/georchestra/tasks/gn-cloud-searching.yml
@@ -1,0 +1,42 @@
+- name: install the gn-cloud-searching microservice
+  get_url:
+    url: "{{ gn_cloud_searching.url }}"
+    dest: "/usr/share/lib/georchestra-gn-cloud-searching.zip"
+    headers:
+      Authorization: "Bearer {{ github_action_token }}"
+
+- name: unzips the war
+  unarchive:
+    src: "/usr/share/lib/georchestra-gn-cloud-searching.zip"
+    dest: /usr/share/lib
+    remote_src: yes
+
+- name: removes the downloaded archive
+  file:
+    path: "/usr/share/lib/georchestra-gn-cloud-searching.zip"
+    state: absent
+
+- name: prepare a configuration directory for the microservice
+  file:
+    path: "/etc/georchestra/geonetwork/microservices/searching"
+    state: directory
+
+- name: templating a configuration file
+  template:
+    src: "geonetwork/gn-cloud-searching-application.yml.j2"
+    dest: "/etc/georchestra/geonetwork/microservices/searching/application.yml"
+
+
+
+- name: setup a systemd unit file
+  template:
+    src: "geonetwork/gn-cloud-searching.service.j2"
+    dest: "/etc/systemd/system/gn-cloud-searching.service"
+  register: gn_cloud_searching_unitfile
+
+- name: start/enable the datafeeder service
+  systemd:
+    state: restarted
+    daemon_reload: yes
+    name: gn-cloud-searching
+  when: gn_cloud_searching_unitfile.changed

--- a/roles/georchestra/tasks/main.yml
+++ b/roles/georchestra/tasks/main.yml
@@ -34,6 +34,10 @@
   tags: datafeeder
   when: datafeeder.enabled
 
+- include: gn-cloud-searching.yml
+  tags: gn-cloud-searching
+  when: gn_cloud_searching.enabled
+
 - include: nativelibs.yml
   tags: nativelibs
 

--- a/roles/georchestra/templates/geonetwork/gn-cloud-searching-application.yml.j2
+++ b/roles/georchestra/templates/geonetwork/gn-cloud-searching-application.yml.j2
@@ -1,0 +1,90 @@
+server:
+  instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
+spring:
+  rabbitmq.host: localhost
+  cloud:
+    config:
+      discovery:
+        enabled: false
+      enabled: false
+management:
+  health.ldap.enabled: false
+eureka:
+  client:
+    enabled: false
+    registerWithEureka: false
+    fetch-registry: false
+
+gn:
+  datadir: ${java.io.tmpdir}/gn-datadir
+  baseurl: https://{{ georchestra.fqdn }}/geonetwork
+  legacy.url: https://{{ georchestra.fqdn }}/geonetwork
+  linkToLegacyGN4: true
+  language.default: fr
+  site:
+    name: GeoNetwork
+    organization: opensource
+  index:
+    url: http://localhost:9200
+    records: gn-records
+    username:
+    password:
+  api:
+    metadata:
+      license:
+        name: GNU General Public License v2.0
+        url: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+  search:
+    # Full text on all fields
+    # 'queryBase': '${any}',
+    # Full text but more boost on title match
+    queryBase: 'any:(${any}) resourceTitleObject.default:(${any})^2'
+    scoreConfig: >
+      {
+        "boost": "5",
+        "functions": [
+          { // Boost down member of a series
+            "filter": { "exists": { "field": "parentUuid" } },
+            "weight": 0.3
+          },
+          { // Boost down obsolete records
+            "filter": { "match": { "cl_status.key": "obsolete" } },
+            "weight": 0.3
+          },
+          {
+            "gauss": {
+              "dateStamp": {
+                "scale": "365d",
+                "offset": "90d",
+                "decay": 0.5
+              }
+            }
+          }
+        ],
+        "score_mode": "multiply"
+      }
+    sortables:
+      - "relevance"
+      - "createDate:desc"
+      - "resourceTitleObject.default.keyword"
+      - "rating:desc"
+      - "popularity:desc"
+    formats:
+      - name : rss
+        mimeType : application/rss+xml
+        responseProcessor: RssResponseProcessorImpl
+        operations:
+          - items
+    defaultMimeType: text/html
+    sources:
+      - "resourceTitleObject"
+      - "resourceAbstractObject"
+      - "resourceType"
+      - "overview"
+      - "uuid"
+      - "schema"
+      - "link"
+      - "allKeywords"
+      - "contactForResource"
+      - "cl_status"
+      - "edit"

--- a/roles/georchestra/templates/geonetwork/gn-cloud-searching.service.j2
+++ b/roles/georchestra/templates/geonetwork/gn-cloud-searching.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=geOrchestra gn-cloud-searching webservice
+After=syslog.target
+
+[Service]
+User=www-data
+# gn-cloud-* webservices require java >= 11
+ExecStart=/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64/bin/java  -Dsearch_without_sql -Dspring.config.location=/etc/georchestra/geonetwork/microservices/searching/ -Dspring.cloud.bootstrap.enabled=false -Dserver.port={{ gn_cloud_searching.port }} -jar /usr/share/lib/searching.jar
+SuccessExitStatus=143
+StandardOutput=append:{{ logs_basedir }}/gn-cloud-searching.log
+StandardError=append:{{ logs_basedir }}/gn-cloud-searching.log
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This service provides a custom endpoint to get a georss representation of the GeoNetwork index in Elasticsearch, as this is not provided anymore with the v4 of GeoNetwork.

Note: this PR has been created on top of the bullseye branch and has been tested mainly under this version of debian.
