### PR TITLE
Adding the datahub frontend to the Apache deployment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "mygeorchestra" => ["georchestra"]
     }
     # If needed to test a part of the playbook by limiting to a specific tag
-    #ansible.raw_arguments = ["-t", "gn-cloud-searching"]
+    #ansible.raw_arguments = ["-t", "datahub"]
   end
 
   config.vm.post_up_message = "geOrchestra SDI installed, congrats! See https://www.georchestra.org/community.html for help and bug reports"

--- a/playbooks/georchestra.yml
+++ b/playbooks/georchestra.yml
@@ -199,9 +199,13 @@
       enabled: true
       port: 8480
     gn_cloud_searching:
-      enabled: true
+      enabled: false
       port: 8580
-      url: https://api.github.com/repos/georchestra/geonetwork-microservices/actions/artifacts/93336082/zip
+      url: https://api.github.com/repos/georchestra/geonetwork-microservices/actions/artifacts/93336082/zip # expired
+    datahub:
+      enabled: true
+      url: https://api.github.com/repos/georchestra/geonetwork-ui/actions/artifacts/129941483/zip
+      default_api_url: /geonetwork/srv/api # could be set to any other GeoNetwork catalogue, even remote if CORS allows it
   tasks:
     - name: reconfigure Kibana after geerlingguy.kibana
       copy:

--- a/roles/apache/tasks/datahub.yml
+++ b/roles/apache/tasks/datahub.yml
@@ -1,0 +1,36 @@
+- name: install the datahub UI
+  get_url:
+    url: "{{ datahub.url }}"
+    dest: "/var/www/georchestra/htdocs/datahub.zip"
+    headers:
+      Authorization: "Bearer {{ github_action_token }}"
+
+- name: Creates a directory for the datahub
+  file:
+    path: /var/www/georchestra/htdocs/datahub
+    state: directory
+    owner: www-data
+    group: www-data
+    mode: '0755'
+
+- name: unzips the war
+  unarchive:
+    src: "/var/www/georchestra/htdocs/datahub.zip"
+    dest: "/var/www/georchestra/htdocs/datahub"
+    remote_src: yes
+
+- name: templatize the env.js file
+  template:
+    src: "datahub-env.js.j2"
+    dest: "/var/www/georchestra/htdocs/datahub/assets/env.js"
+
+- name: removes the downloaded archive
+  file:
+    path: "/var/www/georchestra/htdocs/datahub.zip"
+    state: absent
+
+- name: templatize the apache config for datahub
+  template:
+    src: "datahub.conf.j2"
+    dest: "/var/www/georchestra/conf/datahub.conf"
+  notify: reload apache2

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -102,6 +102,10 @@
   - { src: common, dest: cadastrapp }
   notify: reload apache2
 
+- include: datahub.yml
+  tags: datahub
+  when: datahub.enabled
+
 - name: template config for gn-cloud-searching
   tags: apache_config
   template:

--- a/roles/apache/templates/datahub-env.js.j2
+++ b/roles/apache/templates/datahub-env.js.j2
@@ -1,0 +1,4 @@
+;((window) => {
+  window['env'] = window['env'] || {}
+  window['env']['apiUrl'] = '{{ datahub.default_api_url }}'
+})(this)

--- a/roles/apache/templates/datahub.conf.j2
+++ b/roles/apache/templates/datahub.conf.j2
@@ -1,0 +1,8 @@
+<Location "/datahub/">
+  RewriteEngine on
+  RewriteBase "/datahub/"
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule "^(.*)$" "index.html"
+</Location>
+ProxyPassMatch ^/datahub/.*$ !


### PR DESCRIPTION
* Also deactivating the gn_cloud_searching service, as the archive on
  github action has expired and no other gh action ran since then.
* I decided to put the datahub in the Apache role, because since this is
  a pure JS / CSS webapp, it made more sense to me to be managed by the
  role which handles the setup of the frontend webserver.

Tests:

* Runtime tested with vagrant, ran a harvesting of Géo2France-dev in the local
  GN4 which is deployed, worked quite well.
* As the setup has been made optional, it did not make sense to add some
  serverspec tests.