### PR TITLE
Misc improvements and fixes

### DIFF
--- a/playbooks/georchestra.yml
+++ b/playbooks/georchestra.yml
@@ -206,8 +206,7 @@
       url: https://api.github.com/repos/georchestra/geonetwork-microservices/actions/artifacts/93336082/zip # expired
     datahub:
       enabled: true
-      # artifact comes from https://github.com/georchestra/geonetwork-ui/commit/c62096291
-      url: https://api.github.com/repos/georchestra/geonetwork-ui/actions/artifacts/129941483/zip
+      url: https://packages.georchestra.org/bot/datahub/datahub.zip
       default_api_url: /geonetwork/srv/api # could be set to any other GeoNetwork catalogue, even remote if CORS allows it
     # Here can be defined a SMTP smarthost
     smtp:

--- a/playbooks/georchestra.yml
+++ b/playbooks/georchestra.yml
@@ -200,10 +200,16 @@
       enabled: true
       port: 8480
     gn_cloud_searching:
-      enabled: false
+      enabled: true
       port: 8580
-      # artifact came from https://github.com/georchestra/geonetwork-microservices/commit/221583d5
-      url: https://api.github.com/repos/georchestra/geonetwork-microservices/actions/artifacts/93336082/zip # expired
+      url: https://packages.georchestra.org/bot/wars/geonetwork-microservices/searching.jar
+    gn_ogc_api_records:
+      enabled: true
+      port: 8680
+      url: https://packages.georchestra.org/bot/wars/geonetwork-microservices/gn-ogc-api-records.jar
+      db_host: localhost:5432
+      gn_context: geonetwork
+      elasticsearch_url: http://localhost:9200
     datahub:
       enabled: true
       url: https://packages.georchestra.org/bot/datahub/datahub.zip

--- a/playbooks/georchestra.yml
+++ b/playbooks/georchestra.yml
@@ -3,6 +3,7 @@
   # note: above host must match the content of the "hosts" file
   become: yes
   roles:
+    - postfix
     - georchestra
     - { role: elastic.elasticsearch, tags: es }
     - { role: geerlingguy.kibana, tags: kibana }
@@ -208,6 +209,11 @@
       # artifact comes from https://github.com/georchestra/geonetwork-ui/commit/c62096291
       url: https://api.github.com/repos/georchestra/geonetwork-ui/actions/artifacts/129941483/zip
       default_api_url: /geonetwork/srv/api # could be set to any other GeoNetwork catalogue, even remote if CORS allows it
+    # Here can be defined a SMTP smarthost
+    smtp:
+      smarthost: gateway:25
+      fqdn: "{{ georchestra.fqdn }}"
+      admin_email: "postmaster@{{ georchestra.fqdn }}"
   tasks:
     - name: reconfigure Kibana after geerlingguy.kibana
       copy:

--- a/playbooks/georchestra.yml
+++ b/playbooks/georchestra.yml
@@ -44,12 +44,6 @@
     }
     # Set here your Github token, which should at least have the 'actions' scope
     github_action_token: secret
-    mapstore: {
-      enabled: True,
-      repo: georchestra/mapstore2-georchestra,
-      artifact_id: 119135632,
-      artifact_sha256: b2803ecc76a3768fdc5e358f23b5c5ce10b02ddc #git commit hash
-    }
     openldap: {
       topdc: georchestra,
       basedn: "dc=georchestra,dc=org", # has to be in the form dc={{ topdc }},dc=xx
@@ -160,10 +154,9 @@
         tomcat: georchestra
         enabled: True
       mapstore:
-        url: https://api.github.com/repos/{{ mapstore.repo }}/actions/artifacts/{{ mapstore.artifact_id }}/zip
+        pkg: georchestra-mapstore
         tomcat: georchestra
-        artifact_sha256: "{{ mapstore.artifact_sha256 }}"
-        enabled: "{{ mapstore.enabled }}"
+        enabled: True
       geoserver:
         pkg: georchestra-geoserver
         tomcat: geoserver

--- a/roles/apache/tasks/datahub.yml
+++ b/roles/apache/tasks/datahub.yml
@@ -2,21 +2,11 @@
   get_url:
     url: "{{ datahub.url }}"
     dest: "/var/www/georchestra/htdocs/datahub.zip"
-    headers:
-      Authorization: "Bearer {{ github_action_token }}"
 
-- name: Creates a directory for the datahub
-  file:
-    path: /var/www/georchestra/htdocs/datahub
-    state: directory
-    owner: www-data
-    group: www-data
-    mode: '0755'
-
-- name: unzips the war
+- name: unzips the datahub archive
   unarchive:
     src: "/var/www/georchestra/htdocs/datahub.zip"
-    dest: "/var/www/georchestra/htdocs/datahub"
+    dest: "/var/www/georchestra/htdocs"
     remote_src: yes
 
 - name: templatize the env.js file

--- a/roles/georchestra/tasks/gn-cloud-searching.yml
+++ b/roles/georchestra/tasks/gn-cloud-searching.yml
@@ -1,20 +1,7 @@
 - name: install the gn-cloud-searching microservice
   get_url:
     url: "{{ gn_cloud_searching.url }}"
-    dest: "/usr/share/lib/georchestra-gn-cloud-searching.zip"
-    headers:
-      Authorization: "Bearer {{ github_action_token }}"
-
-- name: unzips the war
-  unarchive:
-    src: "/usr/share/lib/georchestra-gn-cloud-searching.zip"
-    dest: /usr/share/lib
-    remote_src: yes
-
-- name: removes the downloaded archive
-  file:
-    path: "/usr/share/lib/georchestra-gn-cloud-searching.zip"
-    state: absent
+    dest: "/usr/share/lib/searching.jar"
 
 - name: prepare a configuration directory for the microservice
   file:

--- a/roles/georchestra/tasks/gn-ogc-api-records.yml
+++ b/roles/georchestra/tasks/gn-ogc-api-records.yml
@@ -1,0 +1,27 @@
+- name: install the gn-ogc-api-records microservice
+  get_url:
+    url: "{{ gn_ogc_api_records.url }}"
+    dest: "/usr/share/lib/gn-ogc-api-records.jar"
+
+- name: prepare a configuration directory for the microservice
+  file:
+    path: "/etc/georchestra/geonetwork/microservices/ogc-api-records"
+    state: directory
+
+- name: templating a configuration file
+  template:
+    src: "geonetwork/gn-ogc-api-records-application.yml.j2"
+    dest: "/etc/georchestra/geonetwork/microservices/ogc-api-records/application.yml"
+
+- name: setup a systemd unit file
+  template:
+    src: "geonetwork/gn-ogc-api-records.service.j2"
+    dest: "/etc/systemd/system/gn-ogc-api-records.service"
+  register: gn_ogc_api_records_unitfile
+
+- name: start/enable the gn-ogc-api-records service
+  systemd:
+    state: restarted
+    daemon_reload: yes
+    name: gn-ogc-api-records
+  when: gn_ogc_api_records_unitfile.changed

--- a/roles/georchestra/tasks/main.yml
+++ b/roles/georchestra/tasks/main.yml
@@ -38,6 +38,10 @@
   tags: gn-cloud-searching
   when: gn_cloud_searching.enabled
 
+- include: gn-ogc-api-records.yml
+  tags: gn-ogc-api-records
+  when: gn_ogc_api_records.enabled
+
 - include: nativelibs.yml
   tags: nativelibs
 

--- a/roles/georchestra/templates/geonetwork/gn-ogc-api-records-application.yml.j2
+++ b/roles/georchestra/templates/geonetwork/gn-ogc-api-records-application.yml.j2
@@ -1,7 +1,7 @@
 server:
   port: {{ gn_ogc_api_records.port }}
 #  address: localhost
-#  forward-headers-strategy: NATIVE
+  forward-headers-strategy: framework
 #  servlet:
 #    context-path: /ogcapi
   instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}

--- a/roles/georchestra/templates/geonetwork/gn-ogc-api-records-application.yml.j2
+++ b/roles/georchestra/templates/geonetwork/gn-ogc-api-records-application.yml.j2
@@ -1,0 +1,135 @@
+server:
+  port: {{ gn_ogc_api_records.port }}
+#  address: localhost
+#  forward-headers-strategy: NATIVE
+#  servlet:
+#    context-path: /ogcapi
+  instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
+  servlet:
+    encoding:
+      charset: UTF-8
+      force-response: true
+spring:
+  application.name: ogc-records-service
+  main.banner-mode: off
+  cloud:
+    loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
+    config:
+      fail-fast: true
+      retry:
+        max-attempts: 20
+      discovery:
+        enabled: true
+        service-id: config-service
+
+
+---
+# Use this profile when running on a GN4 database on localhost and Elasticsearch index.
+# Turn off security, config & discover.
+spring:
+  profiles: standalone
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://{{ gn_ogc_api_records.db_host }}/{{ georchestra.db.name }}
+    username: {{ geonetwork.db.user }}
+    password: {{ geonetwork.db.pass }}
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    jpa.generate-ddl: false
+    jpa.hibernate.ddl-auto: none
+  cloud:
+    config:
+      discovery:
+        enabled: false
+      enabled: false
+management:
+  health.ldap.enabled: false
+eureka:
+  client:
+    enabled: false
+    registerWithEureka: false
+    fetch-registry: false
+gn:
+  baseurl: https://{{ georchestra.fqdn }}/{{ gn_ogc_api_records.gn_context }}
+  language:
+    default: eng
+  legacy.url: https://{{ georchestra.fqdn }}/{{ gn_ogc_api_records.gn_context }}
+  index:
+    url: {{ gn_ogc_api_records.elasticsearch_url }}
+    records: gn-records
+    username:
+    password:
+  search:
+    formats:
+      - name: html
+        mimeType: text/html
+        responseProcessor: JsonUserAndSelectionAwareResponseProcessorImpl
+        operations:
+          - root
+          - collections
+          - collection
+          - items
+          - item
+      - name: xml
+        mimeType: application/xml
+        responseProcessor: XmlResponseProcessorImpl
+        operations:
+          - root
+          - collections
+          - collection
+          - items
+          - item
+      - name: json
+        mimeType: application/json
+        responseProcessor: JsonUserAndSelectionAwareResponseProcessorImpl
+        operations:
+          - root
+          - collections
+          - collection
+          - items
+          - item
+      - name : gn
+        mimeType : application/gn+xml
+        responseProcessor: XsltResponseProcessorImpl
+      - name: opensearch
+        mimeType: application/opensearchdescription+xml
+        operations:
+          - collection
+      - name : schema.org
+        mimeType : application/ld+json
+        responseProcessor: JsonLdResponseProcessorImpl
+        operations:
+          - items
+          - item
+      - name: dcat
+        mimeType: application/rdf+xml
+        responseProcessor: JsonUserAndSelectionAwareResponseProcessorImpl
+        operations:
+          - item
+      - name : dcat_turtle
+        mimeType : text/turtle
+        responseProcessor: JsonUserAndSelectionAwareResponseProcessorImpl
+        operations :
+          - item
+      - name : rss
+        mimeType : application/rss+xml
+        responseProcessor: RssResponseProcessorImpl
+        operations:
+          - items
+    defaultMimeType: text/html
+logging:
+  level:
+    # geonetwork roots
+    org.fao.geonet: INFO
+    org.fao.geonet.ogcapi: INFO
+    org.fao.geonet.searching: INFO
+springfox:
+  documentation:
+    swaggerUi:
+      baseUrl: /openapi
+    openApi:
+      v3:
+        path: /openapi/v3/api-docs
+    swagger:
+      v2 :
+        path: /openapi/v2/api-docs

--- a/roles/georchestra/templates/geonetwork/gn-ogc-api-records.service.j2
+++ b/roles/georchestra/templates/geonetwork/gn-ogc-api-records.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=geOrchestra gn-ogc-api-records webservice
+After=syslog.target
+
+[Service]
+User=www-data
+# gn-cloud-* webservices require java >= 11
+ExecStart=/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64/bin/java -Dserver.servlet.context-path=/ogc-api-records -Dspring.profiles.active=standalone  -Dspring.config.location=/etc/georchestra/geonetwork/microservices/ogc-api-records/application.yml -Dspring.cloud.bootstrap.enabled=false -jar /usr/share/lib/gn-ogc-api-records.jar
+SuccessExitStatus=143
+StandardOutput=append:{{ logs_basedir }}/gn-ogc-api-records.log
+StandardError=append:{{ logs_basedir }}/gn-ogc-api-records.log
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/georchestra/templates/security-proxy/targets-mapping.properties.j2
+++ b/roles/georchestra/templates/security-proxy/targets-mapping.properties.j2
@@ -6,3 +6,6 @@
 {% if datafeeder.enabled %}
 datafeeder=http://localhost:{{ datafeeder.port }}/datafeeder/
 {% endif %}
+{% if gn_ogc_api_records.enabled %}
+ogc-api-records=http://localhost:{{ gn_ogc_api_records.port }}/ogc-api-records
+{% endif %}

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: set debconf values
+  debconf:
+    name: postfix
+    vtype: "{{ item.type }}"
+    question: "{{ item.key }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { key: postfix/main_mailer_type, type: string, value: 'Satellite system' }
+    - { key: postfix/mailname, type: string, value: '{{ smtp.fqdn }}' }
+    - { key: postfix/relayhost, type: string, value: '{{ smtp.smarthost }}' }
+    - { key: postfix/root_address, type: string, value: '{{ smtp.admin_email }}' }
+
+- name: installs postfix
+  apt:
+    name: postfix
+    state: present
+    update_cache: yes

--- a/roles/tomcat/templates/server-proxycas.xml.j2
+++ b/roles/tomcat/templates/server-proxycas.xml.j2
@@ -46,19 +46,19 @@
   </GlobalNamingResources>
 
   <!-- A "Service" is a collection of one or more "Connectors" that share
-       a single "Container" Note:  A "Service" is not itself a "Container", 
+       a single "Container" Note:  A "Service" is not itself a "Container",
        so you may not define subcomponents such as "Valves" at this level.
        Documentation at /docs/config/service.html
    -->
   <Service name="Catalina">
-  
+
     <!--The connectors can use a shared executor, you can define one or more named thread pools-->
     <!--
-    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-" 
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
         maxThreads="150" minSpareThreads="4"/>
     -->
-    
-    
+
+
     <!-- A "Connector" represents an endpoint by which requests are received
          and responses are returned. Documentation at :
          Java HTTP Connector: /docs/config/http.html (blocking & non-blocking)
@@ -66,33 +66,20 @@
          APR (HTTP/AJP) Connector: /docs/apr.html
          Define a non-SSL HTTP/1.1 Connector on port 8080
     -->
-    <Connector port="8180" protocol="HTTP/1.1" 
-               connectionTimeout="20000" 
+    <Connector port="8180" protocol="HTTP/1.1"
+               connectionTimeout="20000"
                URIEncoding="UTF-8"
                redirectPort="8443" />
 
-<Connector port="8443" protocol="HTTP/1.1" 
-               SSLEnabled="true" 
-               scheme="https" 
-               secure="true"
-               URIEncoding="UTF-8"
-               maxThreads="150"
-               clientAuth="false"
-               keystoreFile="/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/jre/lib/security/cacerts"
-               keystorePass="changeit"
-               compression="on"
-               compressionMinSize="2048"
-               noCompressionUserAgents="gozilla, traviata"
-               compressableMimeType="text/html,text/xml,application/xml,text/javascript,application/x-javascript,application/javascript,text/css" />
     <!-- A "Connector" using the shared thread pool-->
     <!--
     <Connector executor="tomcatThreadPool"
-               port="8080" protocol="HTTP/1.1" 
-               connectionTimeout="20000" 
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
                redirectPort="8443" />
-    -->           
+    -->
     <!-- Define a SSL HTTP/1.1 Connector on port 8443
-         This connector uses the JSSE configuration, when using APR, the 
+         This connector uses the JSSE configuration, when using APR, the
          connector should be using the OpenSSL style configuration
          described in the APR documentation -->
     <!--
@@ -114,8 +101,8 @@
          Documentation at /docs/config/engine.html -->
 
     <!-- You should set jvmRoute to support load-balancing via AJP ie :
-    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">         
-    --> 
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
     <Engine name="Catalina" defaultHost="localhost">
 
       <!--For clustering, please take a look at documentation at:
@@ -123,7 +110,7 @@
           /docs/config/cluster.html (reference documentation) -->
       <!--
       <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
-      -->        
+      -->
 
       <!-- The request dumper valve dumps useful debugging information about
            the request and response data received and sent by Tomcat.
@@ -158,10 +145,10 @@
         <!-- Access log processes all example.
              Documentation at: /docs/config/valve.html -->
         <!--
-        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"  
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log." suffix=".txt" pattern="common" resolveHosts="false"/>
         -->
-        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="{{ logs_basedir }}"  
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="{{ logs_basedir }}"
                prefix="access-proxycas" suffix=".txt" pattern="%{X-Forwarded-For}i %l %u %t %r %s %b"/>
 
       </Host>

--- a/spec/georchestra/georchestra_spec.rb
+++ b/spec/georchestra/georchestra_spec.rb
@@ -9,7 +9,13 @@ describe port(80) do
   it { should be_listening }
 end
 
+# Frontend webserver TLS (apache2)
 describe port(443) do
+  it { should be_listening }
+end
+
+# Mailserver
+describe port(25) do
   it { should be_listening }
 end
 

--- a/spec/georchestra/georchestra_spec.rb
+++ b/spec/georchestra/georchestra_spec.rb
@@ -54,7 +54,8 @@ describe port(8180) do
   it { should be_listening }
 end
 
-describe port(8443) do
+# datafeeder
+describe port(8480) do
   it { should be_listening }
 end
 

--- a/spec/georchestra/georchestra_spec.rb
+++ b/spec/georchestra/georchestra_spec.rb
@@ -58,8 +58,13 @@ describe port(8443) do
   it { should be_listening }
 end
 
-# datafeeder
-describe port(8480) do
+# gn-cloud-searching
+describe port(8580) do
+  it { should be_listening }
+end
+
+# gn-ogc-api-records
+describe port(8680) do
   it { should be_listening }
 end
 


### PR DESCRIPTION
This PR contains several improvements and fixes, esp. regarding the GN microservices that have been introduced recently.

* Adding a postfix role, so that we have a local SMTP running, needed for the datahub to bootstrap correctly
* relocating the datahub artifact to our own CI: no need to issue to github token, and the artifacts won't expire anymore
* fixing gn-searching (relocating the artifact to our own CI as well)
* introduction of the gn-ogc-api-records microservice
* cleaning up the playbook: removing the 8443 connector from the proxycas tomcat, as it is non-functional (the keystore used as argument does not provide the expected certificate anyway)

Tests: runtime, serverspec updated. Note: to have the serverspec testsuite fully green, I needed some minor manual adjustments:

* gn-ogc-api-records comes to life too fast, before GN has the time to bootstrap a default database, so it requires a manual restart.
* Apache2 strangely does not succeed in configuring a TLS termination either on the first shot, but works fine after a `apache2ctl graceful`.
  
Still in a draft state, as I still have some issues with the ogc-api-records microservice.
