### PR TITLE
gn4.0.6 - fixups

### DIFF
--- a/playbooks/georchestra.yml
+++ b/playbooks/georchestra.yml
@@ -93,7 +93,7 @@
       datadir: {
         path: /srv/data/geonetwork/,
         gitrepo: "https://github.com/georchestra/geonetwork_minimal_datadir",
-        gitversion: gn3.8.2
+        gitversion: gn4.0.6
       }
     }
     geoserver: {

--- a/roles/georchestra/templates/datafeeder/frontend-config.json.j2
+++ b/roles/georchestra/templates/datafeeder/frontend-config.json.j2
@@ -23,5 +23,5 @@
       "value": "EPSG:3857"
     }
   ],
-  "thesaurusUrl": "https://{{ georchestra.fqdn }}/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.inspire-theme&rows=200&q=${q}&uri=**&lang=${lang}"
+  "thesaurusUrl": "https://{{ georchestra.fqdn }}/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.httpinspireeceuropaeutheme-theme&rows=200&q=${q}&uri=**&lang=${lang}"
 }


### PR DESCRIPTION
* Using the gn4.0.6 branch for the minimal datadir
* fix datafeeder thesaurus configuration to map with the expected
  thesaurus key