### PR TITLE
mviewertudio - moving related step to the georchestra role

### DIFF
--- a/roles/apache/tasks/mviewerstudio.yml
+++ b/roles/apache/tasks/mviewerstudio.yml
@@ -27,10 +27,3 @@
   template:
     src: "mviewerstudio/config.json.j2"
     dest: "/var/www/mviewerstudio/apps/config.json"
-
-- name: Mviewerstudio accessible only if connected
-  lineinfile:
-    insertbefore: "<intercept-url pattern=\".*\" "
-    path: "{{ georchestra.datadir.path }}/security-proxy/security-mappings.xml"
-    line: "  <intercept-url pattern=\"/mviewerstudio/.*\" access=\"IS_AUTHENTICATED_FULLY\" />"
-    state: present

--- a/roles/georchestra/tasks/main.yml
+++ b/roles/georchestra/tasks/main.yml
@@ -41,6 +41,10 @@
 - include: nativelibs.yml
   tags: nativelibs
 
+- include: mviewerstudio.yml
+  tags: mviewerstudio
+  when: mviewerstudio.enabled
+
 - include: clean.yml
   tags: [cleanup, georchestra_cleanup]
   when: cleanup is defined

--- a/roles/georchestra/tasks/mviewerstudio.yml
+++ b/roles/georchestra/tasks/mviewerstudio.yml
@@ -1,0 +1,6 @@
+- name: Mviewerstudio accessible only if connected
+  lineinfile:
+    insertbefore: "<intercept-url pattern=\".*\" "
+    path: "{{ georchestra.datadir.path }}/security-proxy/security-mappings.xml"
+    line: "  <intercept-url pattern=\"/mviewerstudio/.*\" access=\"IS_AUTHENTICATED_FULLY\" />"
+    state: present


### PR DESCRIPTION
As discussed via irc, without this change, the ansible playbook will try to modify the security-mappings.xml from the datadir, which is not git cloned yet.

Also it makes more sense to have the configuration step related to georchstra into the georchestra role.