### PR TITLE
atlas - cleaning up roles following removal

### DIFF
--- a/roles/georchestra/templates/default.properties.j2
+++ b/roles/georchestra/templates/default.properties.j2
@@ -28,7 +28,7 @@ headerHeight=90
 headerUrl=/header/
 
 # Administrator email
-# Default email address used to send and receive mails in atlas, console
+# Default email address used to send and receive mails in the console
 # See the corresponding properties files to override this email
 # address for specific needs.
 administratorEmail={{ console_adminemail }}

--- a/roles/postgresql/vars/main.yml
+++ b/roles/postgresql/vars/main.yml
@@ -1,8 +1,7 @@
-other_schemas: [ console, geofence, ogcstatistics, atlas, mapstore, datafeeder ]
+other_schemas: [ console, geofence, ogcstatistics, mapstore, datafeeder ]
 other_schemas_urls:
   - https://raw.github.com/georchestra/georchestra/master/postgresql/040-console.sql
   - https://raw.github.com/georchestra/georchestra/master/postgresql/050-ogc-server-statistics.sql
-  - https://raw.github.com/georchestra/georchestra/master/postgresql/060-atlas.sql
   - https://raw.github.com/georchestra/georchestra/master/postgresql/080-geofence.sql
   - https://raw.github.com/georchestra/georchestra/master/postgresql/110-mapstore.sql
   - https://raw.github.com/georchestra/georchestra/master/postgresql/120-datafeeder.sql


### PR DESCRIPTION
See https://github.com/georchestra/georchestra/issues/3737. Since atlas has been removed in the main georchestra repository, there are still some elements here to be cleaned up.