### PR TITLE
gn-cloud-searching - fixing the GN searching microservice

### DIFF
--- a/roles/georchestra/tasks/gn-cloud-searching.yml
+++ b/roles/georchestra/tasks/gn-cloud-searching.yml
@@ -6,7 +6,7 @@
 - name: templating a configuration file
   template:
     src: "geonetwork/gn-cloud-searching-application.yml.j2"
-    dest: "/etc/georchestra/geonetwork/microservices/searching/gn-cloud-searching-application.yml"
+    dest: "/etc/georchestra/geonetwork/microservices/searching/config.yml"
 
 - name: setup a systemd unit file
   template:

--- a/roles/georchestra/templates/geonetwork/gn-cloud-searching.service.j2
+++ b/roles/georchestra/templates/geonetwork/gn-cloud-searching.service.j2
@@ -5,7 +5,7 @@ After=syslog.target
 [Service]
 User=www-data
 # gn-cloud-* webservices require java >= 11
-ExecStart=/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64/bin/java  -Dsearch_without_sql -Dspring.config.location=/etc/georchestra/geonetwork/microservices/searching/ -Dspring.cloud.bootstrap.enabled=false -Dserver.port={{ gn_cloud_searching.port }} -jar /usr/share/lib/searching.jar
+ExecStart=/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64/bin/java  -Dsearch_without_sql -Dspring.config.location=/etc/georchestra/geonetwork/microservices/searching/config.yml -Dspring.cloud.bootstrap.enabled=false -Dserver.port={{ gn_cloud_searching.port }} -jar /usr/share/lib/searching.jar
 SuccessExitStatus=143
 StandardOutput=append:{{ logs_basedir }}/gn-cloud-searching.log
 StandardError=append:{{ logs_basedir }}/gn-cloud-searching.log

--- a/spec/georchestra/georchestra_spec.rb
+++ b/spec/georchestra/georchestra_spec.rb
@@ -57,6 +57,16 @@ describe port(8480) do
   it { should be_listening }
 end
 
+# gn-cloud-searching
+describe port(8580) do
+  it { should be_listening }
+end
+
+# gn-ogc-api-records
+describe port(8880) do
+  it { should be_listening }
+end
+
 # geOrchestra base debian packages should be present
 [ 'georchestra-analytics',
   'georchestra-cas',


### PR DESCRIPTION
using a file as config.spring.location instead of a directory, as we have only one provided as a template.

Also adding a serverspec to test it (along with another one for the gn ogc-api-records microservice).