### PR TITLE
removing tomcat ssl connector on proxycas instance (#115)

### DIFF
--- a/roles/tomcat/templates/server-proxycas.xml.j2
+++ b/roles/tomcat/templates/server-proxycas.xml.j2
@@ -71,19 +71,6 @@
                URIEncoding="UTF-8"
                redirectPort="8443" />
 
-<Connector port="8443" protocol="HTTP/1.1"
-               SSLEnabled="true"
-               scheme="https"
-               secure="true"
-               URIEncoding="UTF-8"
-               maxThreads="150"
-               clientAuth="false"
-               keystoreFile="/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64/lib/security/cacerts"
-               keystorePass="changeit"
-               compression="on"
-               compressionMinSize="2048"
-               noCompressionUserAgents="gozilla, traviata"
-               compressableMimeType="text/html,text/xml,application/xml,text/javascript,application/x-javascript,application/javascript,text/css" />
     <!-- A "Connector" using the shared thread pool-->
     <!--
     <Connector executor="tomcatThreadPool"

--- a/spec/georchestra/georchestra_spec.rb
+++ b/spec/georchestra/georchestra_spec.rb
@@ -48,10 +48,6 @@ describe port(8180) do
   it { should be_listening }
 end
 
-describe port(8443) do
-  it { should be_listening }
-end
-
 # datafeeder
 describe port(8480) do
   it { should be_listening }


### PR DESCRIPTION
Note: there are still some occurences for "8443" in the repository, but related to the redirectPort, and even if I am not sure if this is still needed, I think it comes from the default tomcat configuration. I am pretty sure we can leave them as they are, as it won't harm. In the other tomcat configurations, they appear in a commented block.

Also I kept all the logic of trusting the generated self signed certificate, because I think it should be still in use by the JVM / server-to-server communication.