### PR TITLE
Adding the /whoami endpoint of the SP / gateway

### DIFF
--- a/roles/apache/templates/common.conf.j2
+++ b/roles/apache/templates/common.conf.j2
@@ -20,6 +20,9 @@ ProxyPassReverse /gateway http://localhost:{{ tomcat_instances['proxycas']['port
 ProxyPass /testPage http://localhost:{{ tomcat_instances['proxycas']['port'] }}/testPage
 ProxyPassReverse /testPage http://localhost:{{ tomcat_instances['proxycas']['port'] }}/testPage
 
+ProxyPass /whoami http://localhost:{{ tomcat_instances['proxycas']['port'] }}/whoami
+ProxyPassReverse /whoami http://localhost:{{ tomcat_instances['proxycas']['port'] }}/whoami
+
 SetEnvIf Referer "^https://{{ georchestra.fqdn|replace('.','\.') }}/" mysdi
 {% endif %}
 <Proxy http://localhost:{{ tomcat_instances['proxycas']['port'] }}/{{ item.dest }}/*>


### PR DESCRIPTION
Following https://github.com/georchestra/georchestra/pull/3898, this is more or less needed by the datahub and/or the header currently being reworked.

Tests: already applied on demo.g.o