### PR TITLE
serverspec - fixing testsuite (testing nginx, not apache2 package presence)

### DIFF
--- a/spec/georchestra/georchestra_spec.rb
+++ b/spec/georchestra/georchestra_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe package('apache2') do
+describe package('nginx') do
   it { should be_installed }
 end
 


### PR DESCRIPTION
Following https://github.com/georchestra/ansible/pull/127, we now have to test nginx package presence, not apache2 anymore.

Note: I was able to have the serverspec testsuite all green but I had to manually install a SMTP server in the vagrant box, and relaunch the Datafeeder microservice, bootstrap GN (loading default templates + sample MDs), then launch the gn-ogc-api-records service.
