### PR TITLE
gateway - run the georchestra gateway with a Java runtime 21 (fixes geor/geor#4285)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,8 +33,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.groups = {
       "mygeorchestra" => ["georchestra"]
     }
-    # If needed to test a part of the playbook by limiting to a specific tag
-    #ansible.raw_arguments = ["-t", "datahub"]
+    # If needed to pass arguments to ansible, then you can use the ANSIBLE_ARGS environment variables, e.g.:
+    # ANSIBLE_ARGS="-t datahub" vagrant provision
+    ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
   end
 
   config.vm.post_up_message = "geOrchestra SDI installed, congrats! See https://www.georchestra.org/community.html for help and bug reports"

--- a/roles/georchestra/tasks/gateway.yml
+++ b/roles/georchestra/tasks/gateway.yml
@@ -1,4 +1,19 @@
 ---
+- name: Add the adoptium signing key
+  apt_key:
+    url: https://packages.adoptium.net/artifactory/api/gpg/key/public
+    state: present
+
+- name: Set up the adoptium debian repository
+  apt_repository:
+    repo: deb https://packages.adoptium.net/artifactory/deb/ bookworm main
+    state: present
+
+- name: Install temurin-21-jre
+  apt:
+    pkg: temurin-21-jre
+    state: latest
+
 - name: install the georchestra-gateway package
   apt:
     pkg: georchestra-gateway

--- a/roles/georchestra/tasks/gateway.yml
+++ b/roles/georchestra/tasks/gateway.yml
@@ -14,6 +14,11 @@
     pkg: temurin-21-jre
     state: latest
 
+- name: alternatives - back to java 17 as default jvm
+  community.general.alternatives:
+    name: java
+    path: /usr/lib/jvm/java-17-openjdk-amd64/bin/java
+
 - name: install the georchestra-gateway package
   apt:
     pkg: georchestra-gateway

--- a/roles/georchestra/templates/gateway/systemd/gateway.service.j2
+++ b/roles/georchestra/templates/gateway/systemd/gateway.service.j2
@@ -4,7 +4,7 @@ After=syslog.target
 
 [Service]
 User=www-data
-ExecStart=/usr/bin/java -Dserver.port={{ gateway.port }} -Dgeorchestra.datadir=/etc/georchestra -jar /usr/share/lib/georchestra-gateway/georchestra-gateway.jar
+ExecStart=/usr/lib/jvm/temurin-21-jre-amd64/bin/java -Dserver.port={{ gateway.port }} -Dgeorchestra.datadir=/etc/georchestra -jar /usr/share/lib/georchestra-gateway/georchestra-gateway.jar
 SuccessExitStatus=143
 StandardOutput=append:{{ logs_basedir }}/gateway.log
 StandardError=append:{{ logs_basedir }}/gateway.log


### PR DESCRIPTION
Hopefully a JRE 21 will be available in the next debian release, but waiting for it, we can set up a temurin-21-jre from adoptium, see https://github.com/georchestra/georchestra/issues/4285

Tests:
* rspec ok after having installed exim4-base and relaunched the DF
* runtime tests ok: weird redirection to CAS, but able to log in by hitting /login directly (through the georchestra gateway).