### PR TITLE
Update roles and requirements to use ansible version 2.18.0

### DIFF
--- a/playbooks/georchestra.yml
+++ b/playbooks/georchestra.yml
@@ -30,9 +30,9 @@
     #es_data_dirs:
     #  - /srv/elasticsearch/data
     #es_log_dir: /srv/elasticsearch/logs
-    #es_config:
-    #  cluster.name: "{{ georchestra.fqdn }}"
-    #  bootstrap.memory_lock: true
+    elasticsearch_extra_options: |  # Dont forget the pipe!
+      cluster.name: "{{ georchestra.fqdn }}"
+      bootstrap.memory_lock: true
     elasticsearch_heap_size_min: 1g
     elasticsearch_heap_size_max: 2g
     cadastrapp:

--- a/playbooks/georchestra.yml
+++ b/playbooks/georchestra.yml
@@ -5,7 +5,7 @@
   become: true
   roles:
     - { role: georchestra, tags: georchestra }
-    - { role: elastic.elasticsearch, tags: es }
+    - { role: geerlingguy.elasticsearch, tags: es }
     - { role: geerlingguy.kibana, tags: kibana }
   vars:
     georchestra_versions:
@@ -25,14 +25,16 @@
     java_version: java-17-openjdk-amd64
     tomcat_version: 9
     kibana_server_host: 127.0.0.1
-    es_version: 7.17.22
-    es_data_dirs:
-      - /srv/elasticsearch/data
-    es_log_dir: /srv/elasticsearch/logs
-    es_config:
-      cluster.name: "{{ georchestra.fqdn }}"
-      bootstrap.memory_lock: true
-    es_heap_size: 1g
+    elasticsearch_version: '7.x'
+    # TODO update configuration in post installation
+    #es_data_dirs:
+    #  - /srv/elasticsearch/data
+    #es_log_dir: /srv/elasticsearch/logs
+    #es_config:
+    #  cluster.name: "{{ georchestra.fqdn }}"
+    #  bootstrap.memory_lock: true
+    elasticsearch_heap_size_min: 1g
+    elasticsearch_heap_size_max: 2g
     cadastrapp:
       enabled: false
       db:

--- a/playbooks/georchestra.yml
+++ b/playbooks/georchestra.yml
@@ -5,7 +5,7 @@
   become: true
   roles:
     - { role: georchestra, tags: georchestra }
-    - { role: geerlingguy.elasticsearch, tags: es }
+    - { role: ansible-role-elasticsearch, tags: es }
     - { role: geerlingguy.kibana, tags: kibana }
   vars:
     georchestra_versions:
@@ -26,11 +26,9 @@
     tomcat_version: 9
     kibana_server_host: 127.0.0.1
     elasticsearch_version: '7.x'
-    # TODO update configuration in post installation
-    #es_data_dirs:
-    #  - /srv/elasticsearch/data
-    #es_log_dir: /srv/elasticsearch/logs
-    elasticsearch_extra_options: |  # Dont forget the pipe!
+    elasticsearch_log: /srv/elasticsearch/logs
+    elasticsearch_data: /srv/elasticsearch/data
+    elasticsearch_extra_options: |  
       cluster.name: "{{ georchestra.fqdn }}"
       bootstrap.memory_lock: true
     elasticsearch_heap_size_min: 1g

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,3 +1,3 @@
 # ansible roles from galaxy
-- elastic.elasticsearch,v7.17.0
-- geerlingguy.kibana,4.0.1
+- geerlingguy.elasticsearch,5.1.2
+- geerlingguy.kibana,4.0.2

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,3 +1,4 @@
 # ansible roles from galaxy
-- geerlingguy.elasticsearch,5.1.2
+- src: https://github.com/jdev-org/ansible-role-elasticsearch
+  version: 5.1.3
 - geerlingguy.kibana,4.0.2


### PR DESCRIPTION
Link to #142 

update Kibana role to be able to use ansible 2.18.0

for elasticsearch I had to fork ansible role  since elasticsearch role is archived (https://github.com/elastic/ansible-elasticsearch) and  geerlingguy is not responding ( https://github.com/geerlingguy/ansible-role-elasticsearch ) 

