### PR TITLE
[nginx] deploy future gn-ui-based md editor

### DIFF
--- a/playbooks/georchestra.yml
+++ b/playbooks/georchestra.yml
@@ -234,6 +234,9 @@
       enabled: true
       url: https://packages.georchestra.org/bot/datahub/datahub.zip
       default_api_url: /geonetwork/srv/api # could be set to any other GeoNetwork catalogue, even remote if CORS allows it
+    mdeditor:
+      enabled: false
+      url: https://github.com/geonetwork/geonetwork-ui/releases/download/v2.4.0-alpha.2/metadata-editor-2.4.0-alpha.2.zip
     mviewer:
       enabled: true
       port: 8680

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -23,6 +23,10 @@
   when: datahub.enabled
   tags: datahub
 
+- import_tasks: mdeditor.yml
+  when: mdeditor.enabled
+  tags: mdeditor
+
 - import_tasks: generate_cert.yml
   when: force_https
 

--- a/roles/nginx/tasks/mdeditor.yml
+++ b/roles/nginx/tasks/mdeditor.yml
@@ -1,0 +1,24 @@
+---
+- name: Fetch/unzip the mdeditor archive
+  unarchive:
+    src: "{{ mdeditor.url }}"
+    dest: /var/www/georchestra/htdocs/
+    remote_src: true
+
+- name: Symlink to subdir
+  file:
+    src: dist/apps/metadata-editor
+    dest: /var/www/georchestra/htdocs/metadata-editor
+    state: link
+
+- name: set base url in index.html
+  replace:
+    path: /var/www/georchestra/htdocs/metadata-editor/index.html
+    regexp: <base href="/">
+    replace: <base href="/metadata-editor/">
+
+- name: add geor-header webcomponent in index.html
+  lineinfile:
+    path: /var/www/georchestra/htdocs/metadata-editor/index.html
+    insertafter: <body>
+    line: "<script src='https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js'></script><geor-header></geor-header>"

--- a/roles/nginx/templates/vhost.j2
+++ b/roles/nginx/templates/vhost.j2
@@ -132,4 +132,20 @@ server {
 		}
 	}
 {% endif %}
+{% if mdeditor.enabled %}
+
+	location /metadata-editor {
+		try_files $uri $uri/ /metadata-editor/index.html;
+		add_header Cache-Control 'max-age=86400'; # 24h
+		# catch login requests that don't reach the sec-proxy, and redirect to CAS
+		if ( $args ~ '\blogin[=&]?' ) {
+			return 301 /cas/login?service=https%3A%2F%2F{{ georchestra.fqdn }}%2Flogin%2Fcas;
+		}
+		location ~ /index.html|.*\.toml|.*\.json$ {
+			expires -1;
+			add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+		}
+	}
+{% endif %}
+}
 }


### PR DESCRIPTION
[2.4.0-alpha2](https://github.com/geonetwork/geonetwork-ui/releases/tag/v2.4.0-alpha.2) tech preview, not enabled by default

deployment is fine here, the only issue is the injection of the georchestra header that triggers a page scrollbar on the right, eg the bottom of the page with the testadmin badge on the left isnt visible. no such issue on the datahub... any idea @f-necas ? ive tried blindly adding `class="overflow-y-scroll"` to the `<html>` tag as it was the only obvious difference with the datahub, but that didnt help.