### PR TITLE
configure geor-header from playbook variables

### DIFF
--- a/playbooks/georchestra.yml
+++ b/playbooks/georchestra.yml
@@ -96,6 +96,14 @@
       debian:
         repo: "{{ georchestra_versions.debian_repository_url }}"
         key: https://packages.georchestra.org/debian/landry%40georchestra.org.gpg.pubkey
+      header:
+        height: 80
+        script: https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js
+        logourl: https://www.georchestra.org/public/georchestra-logo.svg
+        legacy: "false"
+        legacyurl: /header/
+#        stylesheet: /public/stylesheet.css
+#        configfile: /public/config.json
     geonetwork:
       microservice_version: 4.4.6-1
       db:

--- a/roles/georchestra/templates/default.properties.j2
+++ b/roles/georchestra/templates/default.properties.j2
@@ -19,38 +19,44 @@ language=en
 
 # Header script for web component header
 # https://github.com/georchestra/header
-headerScript=https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js
+headerScript={{ georchestra.header.script | default('https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js') }}
 
 # Header height (size in px)
 # If different from default value "90", adapt analytics/js/GEOR_custom.js
 # accordingly
-headerHeight=90
+headerHeight={{ georchestra.header.height | default('80') }}
 
 # Variable use to keep the old iframe header.
 # Set headerUrl accordingly
 # Default false
-useLegacyHeader=false
+useLegacyHeader={{ georchestra.header.legacy | default ('false') }}
 
 # Header URL (can be absolute or relative). It is used only if useLegacyHeader is set to true.
 # If different from default value "/header/", adapt
 # security-proxy/targets-mapping.properties accordingly
 # default /header/
-headerUrl=/header/
+headerUrl={{ georchestra.header.legacyurl | default ('/header/') }}
 
 # Stylesheet used to override default colors of header
 # More design can be set by overriding default classes & styles
 # Default empty string
 # georchestraStylesheet=/public/stylesheet.css
+{% if georchestra.header.stylesheet is defined %}
+georchestraStylesheet={{ georchestra.header.stylesheet }}
+{% endif %}
 
 # Config file for the header webcomponent
 # You can use this file to change the menu design, add new items, etc.
 # Full configuration can be found here: https://github.com/georchestra/header/
 # Default empty string
 # headerConfigFile=/public/config.json
+{% if georchestra.header.configfile is defined %}
+headerConfigFile={{ georchestra.header.configfile }}
+{% endif %}
 
 # Logo URL
 # Used to set header's logo.
-logoUrl=https://www.georchestra.org/public/georchestra-logo.svg
+logoUrl={{ georchestra.header.logourl | default('https://www.georchestra.org/public/georchestra-logo.svg') }}
 
 
 # Administrator email

--- a/roles/georchestra/templates/mapstore/localConfig.json.j2
+++ b/roles/georchestra/templates/mapstore/localConfig.json.j2
@@ -20,13 +20,13 @@
     },
     "stylesheetUri": "",
     "header": {
-      "height": 80,
-      "url": "/header/",
-      "script": "https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js",
-      "legacy": false,
-      "logoUrl": "https://www.georchestra.org/public/georchestra-logo.svg",
-      "stylesheet": "",
-      "configFile": ""
+      "height": {{ georchestra.header.height | default (80) }},
+      "url": "{{ georchestra.header.legacyurl | default('/header/') }}",
+      "script": "{{ georchestra.header.script | default ('https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js') }}",
+      "legacy": {{ georchestra.header.legacy | default('false') }},
+      "logoUrl": "{{ georchestra.header.logourl | default('https://www.georchestra.org/public/georchestra-logo.svg') }}",
+      "stylesheet": "{{ georchestra.header.stylesheet | default('') }}",
+      "configFile": "{{ georchestra.header.configfile | default('') }}"
     },
     "defaultMapOptions": {
       "cesium": {

--- a/roles/nginx/tasks/datahub.yml
+++ b/roles/nginx/tasks/datahub.yml
@@ -23,7 +23,19 @@
     replace: <base href="/datahub/">
 
 - name: add geor-header webcomponent in index.html
-  lineinfile:
+  blockinfile:
     path: /var/www/georchestra/htdocs/datahub/index.html
+    marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
     insertafter: <body>
-    line: "<script src='https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js'></script><geor-header></geor-header>"
+    block: |
+      <script src='{{ georchestra.header.script | default('https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js') }}'></script>
+      <geor-header
+        active-app='datahub'
+        {% if georchestra.header.height is defined %}height='{{ georchestra.header.height }}'{% endif %}
+        {% if georchestra.header.logourl is defined %}logo-url='{{ georchestra.header.logourl }}'{% endif %}
+        {% if georchestra.header.legacy is defined %}legacy-header='{{ georchestra.header.legacy }}'{% endif %}
+        {% if georchestra.header.legacyurl is defined %}legacy-url='{{ georchestra.header.legacyurl }}'{% endif %}
+        {% if georchestra.header.stylesheet is defined %}stylesheet='{{ georchestra.header.stylesheet }}'{% endif %}
+        {% if georchestra.header.configfile is defined %}config-file='{{ georchestra.header.configfile }}'{% endif %}
+      >
+      </geor-header>

--- a/roles/nginx/tasks/mdeditor.yml
+++ b/roles/nginx/tasks/mdeditor.yml
@@ -18,7 +18,20 @@
     replace: <base href="/metadata-editor/">
 
 - name: add geor-header webcomponent in index.html
-  lineinfile:
+  blockinfile:
     path: /var/www/georchestra/htdocs/metadata-editor/index.html
+    marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
     insertafter: <body>
-    line: "<style>body {display: flex;flex-direction: column} body md-editor-root,.h-screen {height: calc(100vh - 80px);}</style><script src='https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js'></script><geor-header></geor-header>"
+    block: |
+      <style>body {display: flex;flex-direction: column} body md-editor-root,.h-screen {height: calc(100vh - {{ georchestra.header.height | default(80) }}px);}</style>
+      <script src='{{ georchestra.header.script | default('https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js') }}'></script>
+      <geor-header
+        active-app='metadata-editor'
+        {% if georchestra.header.height is defined %}height='{{ georchestra.header.height }}'{% endif %}
+        {% if georchestra.header.logourl is defined %}logo-url='{{ georchestra.header.logourl }}'{% endif %}
+        {% if georchestra.header.legacy is defined %}legacy-header='{{ georchestra.header.legacy }}'{% endif %}
+        {% if georchestra.header.legacyurl is defined %}legacy-url='{{ georchestra.header.legacyurl }}'{% endif %}
+        {% if georchestra.header.stylesheet is defined %}stylesheet='{{ georchestra.header.stylesheet }}'{% endif %}
+        {% if georchestra.header.configfile is defined %}config-file='{{ georchestra.header.configfile }}'{% endif %}
+      >
+      </geor-header>


### PR DESCRIPTION
works here in my limited testing, allows to properly configure all geor-header vars from a single spot.

ive kept the existing default values, and `headerConfigFile`/`georchestraStylesheet` vars are only templated in `default.properties` if a value is set in the playbook.

feedback/testing welcome.