### PR TITLE
Add support for distinct versions of tomcat for GS3

### DIFF
--- a/playbooks/georchestra.yml
+++ b/playbooks/georchestra.yml
@@ -175,6 +175,7 @@
         xmx: 2G
       geoserver:
         port: 8380
+        version: 11
         control_port: 8305
         xms: 1G
         xmx: 1G

--- a/roles/georchestra/handlers/main.yml
+++ b/roles/georchestra/handlers/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: restart all tomcats
   service:
-    name: tomcat@{{ item }}
+    name: tomcat{{ item.value.version | default (tomcat_version) }}@{{ item.key }}
     state: restarted
-  with_items: "{{ tomcat_instances | list }}"
+  with_dict: "{{ tomcat_instances }}"
 
 - name: restart gn-ogc-api-records
   service:

--- a/roles/georchestra/tasks/geoserver.yml
+++ b/roles/georchestra/tasks/geoserver.yml
@@ -1,5 +1,6 @@
 ---
 - name: set useRelativeRedirects for tomcat geoserver
+  tags: tomcat_config
   replace:
     dest: "{{ tomcat_basedir }}/geoserver/conf/context.xml"
     regexp: <Context>

--- a/roles/georchestra/tasks/wars.yml
+++ b/roles/georchestra/tasks/wars.yml
@@ -77,6 +77,6 @@
 # instances need to be started so that webapps are deployed
 - name: start instances
   service:
-    name: tomcat@{{ item }}
+    name: tomcat{{ item.value.version | default(tomcat_version) }}@{{ item.key }}
     state: started
-  with_items: "{{ tomcat_instances | list }}"
+  with_dict: "{{ tomcat_instances }}"

--- a/roles/postgresql/tasks/clean.yml
+++ b/roles/postgresql/tasks/clean.yml
@@ -2,10 +2,10 @@
 # instances need to be stopped so that the db can be removed
 - name: stop instances
   service:
-    name: tomcat@{{ item }}
+    name: tomcat{{ item.value.version | default(tomcat_version) }}@{{ item.key }}
     enabled: false
     state: stopped
-  with_items: "{{ tomcat_instances | list }}"
+  with_dict: "{{ tomcat_instances }}"
 
 - name: delete georchestra main database
   become: true

--- a/roles/tomcat/tasks/clean.yml
+++ b/roles/tomcat/tasks/clean.yml
@@ -1,10 +1,10 @@
 ---
 - name: stop instances
   service:
-    name: tomcat@{{ item }}
+    name: tomcat{{ item.value.version | default(tomcat_version) }}@{{ item.key }}
     enabled: false
     state: stopped
-  with_items: "{{ tomcat_instances | list }}"
+  with_dict: "{{ tomcat_instances }}"
 
 - name: remove tomcat directories/config
   file:

--- a/roles/tomcat/tasks/common.yml
+++ b/roles/tomcat/tasks/common.yml
@@ -100,13 +100,20 @@
   tags: systemd_unit
   template:
     src: tomcat.service.j2
-    dest: /etc/systemd/system/tomcat@.service
+    dest: /etc/systemd/system/tomcat{{ tomcat_version }}@.service
+
+- name: template systemd unit for tomcat11
+  tags: systemd_unit
+  template:
+    src: tomcat.service.j2
+    dest: /etc/systemd/system/tomcat{{ tomcat_version }}@.service
+  vars:
+    tomcat_version: 11
 
 - name: reload systemd so that it finds the new unit
   tags: systemd_unit
   systemd:
     daemon-reload: true
-    name: tomcat@.service
 
 - name: disable assistive_technologies (requires non-headless jdk)
   lineinfile:

--- a/roles/tomcat/tasks/common.yml
+++ b/roles/tomcat/tasks/common.yml
@@ -51,6 +51,7 @@
     pkg:
       - tomcat{{ tomcat_version }}
       - tomcat{{ tomcat_version }}-user # needed for create-instance script
+      - tomcat11-user
       - tomcat-jakartaee-migration
       - libecj-java
       - libtcnative-1 # APR native libs

--- a/roles/tomcat/tasks/instance.yml
+++ b/roles/tomcat/tasks/instance.yml
@@ -1,14 +1,22 @@
 ---
 - name: Create tomcat instance
   command: >
-    tomcat{{ tomcat_version }}-instance-create -p {{ item.value.port }} -c {{ item.value.control_port }} {{ tomcat_basedir }}/{{ item.key }}
+    tomcat{{ item.version | default (tomcat_version) }}-instance-create -p {{ item.value.port }} -c {{ item.value.control_port }} {{ tomcat_basedir }}/{{ item.key }}
   args:
     creates: "{{ tomcat_basedir }}/{{ item.key }}"
   with_dict: "{{ tomcat_instances }}"
 
+- name: Disable default instance
+  service:
+    name: tomcat{{ item.version }}
+    state: stopped
+    enabled: false
+  when: item.version is defined
+  with_dict: "{{ tomcat_instances }}"
+
 - name: symlink policy.d dir
   file:
-    src: /etc/tomcat{{ tomcat_version }}/policy.d/
+    src: /etc/tomcat{{ item.version | default(tomcat_version) }}/policy.d/
     dest: "{{ tomcat_basedir }}/{{ item.key }}/conf/policy.d"
     state: link
   with_dict: "{{ tomcat_instances }}"
@@ -48,6 +56,6 @@
 
 - name: enable instance
   systemd:
-    name: tomcat@{{ item.key }}
+    name: tomcat{{ item.version | default (tomcat_version) }}@{{ item.key }}
     enabled: true
   with_dict: "{{ tomcat_instances }}"

--- a/roles/tomcat/tasks/instance.yml
+++ b/roles/tomcat/tasks/instance.yml
@@ -1,25 +1,26 @@
 ---
 - name: Create tomcat instance
   command: >
-    tomcat{{ item.version | default (tomcat_version) }}-instance-create -p {{ item.value.port }} -c {{ item.value.control_port }} {{ tomcat_basedir }}/{{ item.key }}
+    tomcat{{ item.value.version | default (tomcat_version) }}-instance-create -p {{ item.value.port }} -c {{ item.value.control_port }} {{ tomcat_basedir }}/{{ item.key }}
   args:
     creates: "{{ tomcat_basedir }}/{{ item.key }}"
   with_dict: "{{ tomcat_instances }}"
 
 - name: Disable default instance
   service:
-    name: tomcat{{ item.version }}
+    name: tomcat{{ item.value.version }}
     state: stopped
     enabled: false
-  when: item.version is defined
+  when: item.value.version is defined
   with_dict: "{{ tomcat_instances }}"
 
 - name: symlink policy.d dir
   file:
-    src: /etc/tomcat{{ item.version | default(tomcat_version) }}/policy.d/
+    src: /etc/tomcat{{ tomcat_version }}/policy.d/
     dest: "{{ tomcat_basedir }}/{{ item.key }}/conf/policy.d"
     state: link
   with_dict: "{{ tomcat_instances }}"
+  when: item.value.version is not defined
 
 - name: recursively fix dirs ownership
   file:
@@ -55,7 +56,8 @@
   when: tomcat_version == 10
 
 - name: enable instance
+  tags: enable_tomcat
   systemd:
-    name: tomcat{{ item.version | default (tomcat_version) }}@{{ item.key }}
+    name: tomcat{{ item.value.version | default (tomcat_version) }}@{{ item.key }}
     enabled: true
   with_dict: "{{ tomcat_instances }}"


### PR DESCRIPTION
In preparation for georchestra/georchestra#4642, GS3 needs tomcat 11.

The PR renames the systemd services from `tomcat@foo` to `tomcatX@foo` to be more explicit.